### PR TITLE
improve performance by reworking the port scan

### DIFF
--- a/gomap_test.go
+++ b/gomap_test.go
@@ -9,9 +9,8 @@ import (
 
 func TestMain(m *testing.M) {
 	fastscan := true
-	results := gomap.ScanRange(fastscan)
-	// results := gomap.ScanIP("192.168.1.120", fastscan)
+	results, _ := gomap.ScanRange(fastscan)
+	// results, _ := gomap.ScanIP("127.0.0.1", fastscan)
 
-	fmt.Printf(results.String())
-
+	fmt.Println(results)
 }


### PR DESCRIPTION
This results in decreasing the fast scan time
from 0.309s to 0.020s for localhost on my machine.

Expose the underlying errors in the public api,
to allow users to handle these themselves.
